### PR TITLE
No filter when opacity = 1

### DIFF
--- a/elements.less
+++ b/elements.less
@@ -3,6 +3,8 @@
   ---------------------------------------------------
     A set of useful LESS mixins
     More info at: http://lesselements.com
+
+    REZO ZERO fork
   ---------------------------------------------------*/
 
 /*
@@ -10,13 +12,13 @@
  */
 .fake-display-none(){
   display: block;
-  .opacity(0);
   pointer-events: none;
+  .opacity(0);
 }
 .fake-display-block(){
   display: block;
-  .opacity(1);
   pointer-events: auto;
+  .opacity(1);
 }
 
 .gradient(@color: #F5F5F5, @start: #EEE, @stop: #FFF) {
@@ -56,68 +58,61 @@
 }
 
 .bordered(@top-color: #EEE, @right-color: #EEE, @bottom-color: #EEE, @left-color: #EEE) {
-  border-top: solid 1px @top-color;
-  border-left: solid 1px @left-color;
-  border-right: solid 1px @right-color;
+  border-top:    solid 1px @top-color;
+  border-left:   solid 1px @left-color;
+  border-right:  solid 1px @right-color;
   border-bottom: solid 1px @bottom-color;
 }
 .drop-shadow(@x-axis: 0, @y-axis: 1px, @blur: 2px, @alpha: 0.1) {
   -webkit-box-shadow: @x-axis @y-axis @blur rgba(0, 0, 0, @alpha);
-  -moz-box-shadow: @x-axis @y-axis @blur rgba(0, 0, 0, @alpha);
-  box-shadow: @x-axis @y-axis @blur rgba(0, 0, 0, @alpha);
+  -moz-box-shadow:    @x-axis @y-axis @blur rgba(0, 0, 0, @alpha);
+  box-shadow:         @x-axis @y-axis @blur rgba(0, 0, 0, @alpha);
 }
 .rounded(@radius: 2px) {
   -webkit-border-radius: @radius;
-  -moz-border-radius: @radius;
-  border-radius: @radius;
+  -moz-border-radius:    @radius;
+  border-radius:         @radius;
 }
 .border-radius(@topright: 0, @bottomright: 0, @bottomleft: 0, @topleft: 0) {
-  -webkit-border-top-right-radius: @topright;
+  -webkit-border-top-right-radius:    @topright;
   -webkit-border-bottom-right-radius: @bottomright;
-  -webkit-border-bottom-left-radius: @bottomleft;
-  -webkit-border-top-left-radius: @topleft;
-  -moz-border-radius-topright: @topright;
-  -moz-border-radius-bottomright: @bottomright;
-  -moz-border-radius-bottomleft: @bottomleft;
-  -moz-border-radius-topleft: @topleft;
-  border-top-right-radius: @topright;
-  border-bottom-right-radius: @bottomright;
-  border-bottom-left-radius: @bottomleft;
-  border-top-left-radius: @topleft;
+  -webkit-border-bottom-left-radius:  @bottomleft;
+  -webkit-border-top-left-radius:     @topleft;
+  -moz-border-radius-topright:        @topright;
+  -moz-border-radius-bottomright:     @bottomright;
+  -moz-border-radius-bottomleft:      @bottomleft;
+  -moz-border-radius-topleft:         @topleft;
+  border-top-right-radius:            @topright;
+  border-bottom-right-radius:         @bottomright;
+  border-bottom-left-radius:          @bottomleft;
+  border-top-left-radius:             @topleft;
   .background-clip(padding-box);
 }
 
 .opacity(@opacity: 0.5) {
-  -moz-opacity: @opacity;
-  -khtml-opacity: @opacity;
+  -moz-opacity:    @opacity;
+  -khtml-opacity:  @opacity;
   -webkit-opacity: @opacity;
-  opacity: @opacity;
-  @opperc: @opacity * 100;
-  -ms-filter: ~"progid:DXImageTransform.Microsoft.Alpha(opacity=@{opperc})";
-  filter: ~"alpha(opacity=@{opperc})";
+  opacity:         @opacity;
+  @opperc:         @opacity * 100;
+  -ms-filter:      ~"progid:DXImageTransform.Microsoft.Alpha(opacity=@{opperc})";
+  filter:          ~"alpha(opacity=@{opperc})";
 }
 .opacity(@opacity: 0.5) when (@opacity = 1) {
-    -moz-opacity: @opacity;
-  -khtml-opacity: @opacity;
+  -moz-opacity:    @opacity;
+  -khtml-opacity:  @opacity;
   -webkit-opacity: @opacity;
-  opacity: @opacity;
-
-  -ms-filter: none;
-  filter: none;  
+  opacity:         @opacity;
+  -ms-filter:      none;
+  filter:          none;  
 }
 
-.transition-duration(@duration: 0.2s) {
-  -moz-transition-duration: @duration;
-  -webkit-transition-duration: @duration;
-  -o-transition-duration: @duration;
-  transition-duration: @duration;
-}
 .transform(...) {
   -webkit-transform: @arguments;
-  -moz-transform: @arguments;
-  -o-transform: @arguments;
-  -ms-transform: @arguments;
-  transform: @arguments;
+  -moz-transform:    @arguments;
+  -o-transform:      @arguments;
+  -ms-transform:     @arguments;
+  transform:         @arguments;
 }
 .rotation(@deg:5deg){
   .transform(rotate(@deg));
@@ -125,50 +120,102 @@
 .scale(@ratio:1.5){
   .transform(scale(@ratio));
 }
-.transition(@duration:0.2s, @ease:ease-out) {
-  -webkit-transition: all @duration @ease;
-  -moz-transition: all @duration @ease;
-  -o-transition: all @duration @ease;
-  transition: all @duration @ease;
+/*
+ * Transitions
+ */
+.transition(...) {
+  -webkit-transition: @arguments;
+  -moz-transition:    @arguments;
+  -o-transition:      @arguments;
+  transition:         @arguments;
 }
+// BAD to transition over ALL propeties ! 
+//.transition(@duration:0.2s, @ease:ease-in-out) {
+//  -webkit-transition: all @duration @ease;
+//  -moz-transition: all @duration @ease;
+//  -o-transition: all @duration @ease;
+//  transition: all @duration @ease;
+//}
+.transition-duration(@duration: 0.2s) {
+  -moz-transition-duration:    @duration;
+  -webkit-transition-duration: @duration;
+  -o-transition-duration:      @duration;
+  transition-duration:         @duration;
+}
+.transition-delay(@delay: 0s) {
+  -moz-transition-delay:    @delay;
+  -webkit-transition-delay: @delay;
+  -o-transition-delay:      @delay;
+  transition-delay:         @delay;
+}
+.transition-property(@property: 0s) {
+  -moz-transition-property:    @property;
+  -webkit-transition-property: @property;
+  -o-transition-property:      @property;
+  transition-property:         @property;
+}
+// Enable transitions on transforms for each vendor
+.transform-transition(...) {
+  -moz-transition :    -moz-transform @arguments;
+  -webkit-transition : -webkit-transform @arguments;
+  -ms-transition :     -ms-transform @arguments;
+  -o-transition :      -o-transform @arguments;
+  transition :         transform @arguments;
+}
+.easeInOutCubic() {
+  -webkit-transition-timing-function: cubic-bezier(0.645, 0.045, 0.355, 1.000); 
+  -moz-transition-timing-function:    cubic-bezier(0.645, 0.045, 0.355, 1.000); 
+  -ms-transition-timing-function:     cubic-bezier(0.645, 0.045, 0.355, 1.000); 
+  -o-transition-timing-function:      cubic-bezier(0.645, 0.045, 0.355, 1.000); 
+  transition-timing-function:         cubic-bezier(0.645, 0.045, 0.355, 1.000);
+}
+.transform-origin( @x, @y ) {
+  -webkit-transform-origin : @x @y;
+  -ms-transform-origin :     @x @y;
+  -moz-transform-origin :    @x @y;
+  -o-transform-origin :      @x @y;
+  transform-origin :         @x @y;
+}
+
+
 .inner-shadow(@horizontal:0, @vertical:1px, @blur:2px, @alpha: 0.4) {
   -webkit-box-shadow: inset @horizontal @vertical @blur rgba(0, 0, 0, @alpha);
-  -moz-box-shadow: inset @horizontal @vertical @blur rgba(0, 0, 0, @alpha);
-  box-shadow: inset @horizontal @vertical @blur rgba(0, 0, 0, @alpha);
+  -moz-box-shadow:    inset @horizontal @vertical @blur rgba(0, 0, 0, @alpha);
+  box-shadow:         inset @horizontal @vertical @blur rgba(0, 0, 0, @alpha);
 }
 .box-shadow(@arguments) {
   -webkit-box-shadow: @arguments;
-  -moz-box-shadow: @arguments;
-  box-shadow: @arguments;
+  -moz-box-shadow:    @arguments;
+  box-shadow:         @arguments;
 }
 .box-sizing(@sizing: border-box) {
-  -ms-box-sizing: @sizing;
-  -moz-box-sizing: @sizing;
+  -ms-box-sizing:     @sizing;
+  -moz-box-sizing:    @sizing;
   -webkit-box-sizing: @sizing;
-  box-sizing: @sizing;
+  box-sizing:         @sizing;
 }
 .user-select(@argument: none) {
   -webkit-user-select: @argument;
-  -moz-user-select: @argument;
-  -ms-user-select: @argument;
-  user-select: @argument;
+  -moz-user-select:    @argument;
+  -ms-user-select:     @argument;
+  user-select:         @argument;
 }
 .columns(@colwidth: 250px, @colcount: 0, @colgap: 50px, @columnRuleColor: #EEE, @columnRuleStyle: solid, @columnRuleWidth: 1px) {
   -moz-column-width: @colwidth;
   -moz-column-count: @colcount;
-  -moz-column-gap: @colgap;
+  -moz-column-gap:   @colgap;
   -moz-column-rule-color: @columnRuleColor;
   -moz-column-rule-style: @columnRuleStyle;
   -moz-column-rule-width: @columnRuleWidth;
   -webkit-column-width: @colwidth;
   -webkit-column-count: @colcount;
-  -webkit-column-gap: @colgap;
+  -webkit-column-gap:   @colgap;
   -webkit-column-rule-color: @columnRuleColor;
   -webkit-column-rule-style: @columnRuleStyle;
   -webkit-column-rule-width: @columnRuleWidth;
   column-width: @colwidth;
   column-count: @colcount;
-  column-gap: @colgap;
+  column-gap:   @colgap;
   column-rule-color: @columnRuleColor;
   column-rule-style: @columnRuleStyle;
   column-rule-width: @columnRuleWidth;
@@ -183,17 +230,18 @@
 }
 .default-appearence() {
   -webkit-appearance: none;
-  -moz-appearance: none;
-  -ms-appearance: none;
-  -o-appearance: none;
+  -moz-appearance:    none;
+  -ms-appearance:     none;
+  -o-appearance:      none;
+  appearance:         none;
 }
 .keep-image-aspect(){
-  image-rendering:        optimizeSpeed;             /* Legal fallback                 */
-  image-rendering:        pixellated;                /* Firefox                        */
-  image-rendering:        -o-crisp-edges;            /* Opera                          */
-  image-rendering:        -webkit-optimize-contrast; /* Chrome (and eventually Safari) */
-  image-rendering:        optimize-contrast;         /* CSS3 Proposed                  */
-  -ms-interpolation-mode: nearest-neighbor;          /* IE8+ */   
+  image-rendering:       optimizeSpeed;             /* Legal fallback                 */
+  image-rendering:       pixellated;                /* Firefox                        */
+  image-rendering:       -o-crisp-edges;            /* Opera                          */
+  image-rendering:       -webkit-optimize-contrast; /* Chrome (and eventually Safari) */
+  image-rendering:       optimize-contrast;         /* CSS3 Proposed                  */
+  -ms-interpolation-mode:nearest-neighbor;          /* IE8+ */   
 }
 
 .color-placeholder(@color) {
@@ -217,11 +265,11 @@
 
 .clearfloat() { 
   &:after {
-    display:  block;
-    content:  '.';
-    height:   0;
+    display:    block;
+    content:    '.';
+    height:     0;
     visibility: hidden;
-    float:    none;
-    clear:    both;
+    float:      none;
+    clear:      both;
   }
 }

--- a/elements.less
+++ b/elements.less
@@ -129,13 +129,14 @@
   -o-transition:      @arguments;
   transition:         @arguments;
 }
-// BAD to transition over ALL propeties ! 
-//.transition(@duration:0.2s, @ease:ease-in-out) {
-//  -webkit-transition: all @duration @ease;
-//  -moz-transition: all @duration @ease;
-//  -o-transition: all @duration @ease;
-//  transition: all @duration @ease;
-//}
+/* BAD to transition over ALL propeties ! 
+.transition(@duration:0.2s, @ease:ease-in-out) {
+  -webkit-transition: all @duration @ease;
+  -moz-transition: all @duration @ease;
+  -o-transition: all @duration @ease;
+  transition: all @duration @ease;
+}
+*/
 .transition-duration(@duration: 0.2s) {
   -moz-transition-duration:    @duration;
   -webkit-transition-duration: @duration;
@@ -221,12 +222,12 @@
   column-rule-width: @columnRuleWidth;
 }
 .translate(@x:0, @y:0) {
-  .transform(~"translate(@x, @y)");
+  .transform(translate(@x, @y));
 }
 .background-clip(@argument: padding-box) {
-  -moz-background-clip: @argument;
+  -moz-background-clip:    @argument;
   -webkit-background-clip: @argument;
-  background-clip: @argument;
+  background-clip:         @argument;
 }
 .default-appearence() {
   -webkit-appearance: none;

--- a/elements.less
+++ b/elements.less
@@ -70,6 +70,7 @@
   border-top-left-radius: @topleft;
   .background-clip(padding-box);
 }
+
 .opacity(@opacity: 0.5) {
   -moz-opacity: @opacity;
   -khtml-opacity: @opacity;
@@ -79,6 +80,16 @@
   -ms-filter: ~"progid:DXImageTransform.Microsoft.Alpha(opacity=@{opperc})";
   filter: ~"alpha(opacity=@{opperc})";
 }
+.opacity(@opacity: 0.5) when (@opacity = 1) {
+    -moz-opacity: @opacity;
+  -khtml-opacity: @opacity;
+  -webkit-opacity: @opacity;
+  opacity: @opacity;
+
+  -ms-filter: none;
+  filter: none;  
+}
+
 .transition-duration(@duration: 0.2s) {
   -moz-transition-duration: @duration;
   -webkit-transition-duration: @duration;
@@ -153,4 +164,28 @@
   -moz-background-clip: @argument;
   -webkit-background-clip: @argument;
   background-clip: @argument;
+}
+.default-appearence() {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  -ms-appearance: none;
+  -o-appearance: none;
+}
+.keep-image-aspect(){
+  image-rendering:optimizeSpeed;             /* Legal fallback                 */
+  image-rendering:pixellated;              /* Firefox                        */
+  image-rendering:-o-crisp-edges;            /* Opera                          */
+  image-rendering:-webkit-optimize-contrast; /* Chrome (and eventually Safari) */
+  image-rendering:optimize-contrast;         /* CSS3 Proposed                  */
+  -ms-interpolation-mode:nearest-neighbor;   /* IE8+ */   
+}
+.clearfloat() { 
+  &:after {
+    display:  block;
+    content:  '.';
+    height:   0;
+    visibility: hidden;
+    float:    none;
+    clear:    both;
+  }
 }

--- a/elements.less
+++ b/elements.less
@@ -5,6 +5,20 @@
     More info at: http://lesselements.com
   ---------------------------------------------------*/
 
+/*
+ * Emulate display none but keep in render to enable transitions 
+ */
+.fake-display-none(){
+  display: block;
+  .opacity(0);
+  pointer-events: none;
+}
+.fake-display-block(){
+  display: block;
+  .opacity(1);
+  pointer-events: auto;
+}
+
 .gradient(@color: #F5F5F5, @start: #EEE, @stop: #FFF) {
   background: @color;
   background: -webkit-gradient(linear,
@@ -22,6 +36,7 @@
                                  @start);
   filter: e(%("progid:DXImageTransform.Microsoft.gradient(startColorstr='%d', endColorstr='%d', GradientType=0)",@stop,@start));
 }
+
 .bw-gradient(@color: #F5F5F5, @start: 0, @stop: 255) {
   background: @color;
   background: -webkit-gradient(linear,
@@ -39,6 +54,7 @@
                                  rgb(@start,@start,@start));
   filter: e(%("progid:DXImageTransform.Microsoft.gradient(startColorstr='%d', endColorstr='%d', GradientType=0)",rgb(@stop,@stop,@stop),rgb(@start,@start,@start)));
 }
+
 .bordered(@top-color: #EEE, @right-color: #EEE, @bottom-color: #EEE, @left-color: #EEE) {
   border-top: solid 1px @top-color;
   border-left: solid 1px @left-color;
@@ -158,7 +174,7 @@
   column-rule-width: @columnRuleWidth;
 }
 .translate(@x:0, @y:0) {
-  .transform(translate(@x, @y));
+  .transform(~"translate(@x, @y)");
 }
 .background-clip(@argument: padding-box) {
   -moz-background-clip: @argument;
@@ -172,13 +188,33 @@
   -o-appearance: none;
 }
 .keep-image-aspect(){
-  image-rendering:optimizeSpeed;             /* Legal fallback                 */
-  image-rendering:pixellated;              /* Firefox                        */
-  image-rendering:-o-crisp-edges;            /* Opera                          */
-  image-rendering:-webkit-optimize-contrast; /* Chrome (and eventually Safari) */
-  image-rendering:optimize-contrast;         /* CSS3 Proposed                  */
-  -ms-interpolation-mode:nearest-neighbor;   /* IE8+ */   
+  image-rendering:        optimizeSpeed;             /* Legal fallback                 */
+  image-rendering:        pixellated;                /* Firefox                        */
+  image-rendering:        -o-crisp-edges;            /* Opera                          */
+  image-rendering:        -webkit-optimize-contrast; /* Chrome (and eventually Safari) */
+  image-rendering:        optimize-contrast;         /* CSS3 Proposed                  */
+  -ms-interpolation-mode: nearest-neighbor;          /* IE8+ */   
 }
+
+.color-placeholder(@color) {
+  &::-webkit-input-placeholder { /* WebKit browsers */
+      color:@color;
+  }
+  &:-moz-placeholder { /* Mozilla Firefox 4 to 18 */
+      color: @color;
+  }
+  &::-moz-placeholder { /* Mozilla Firefox 19+ */
+      color: @color;
+  }
+  &:-ms-input-placeholder { /* Internet Explorer 10+ */
+      color: @color;
+  } 
+}
+
+.touch-scroll(){
+  -webkit-overflow-scrolling: touch;
+}
+
 .clearfloat() { 
   &:after {
     display:  block;


### PR DESCRIPTION
Need to remove msie filters when opacity is to 100%. It makes images glitch and breakdown font-face rendering !

- Added a useful clearfloat mixin to call in each floating container
- Default appearance is useful to skin search inputs on Mac and iOS
- Keep image aspect is needed when working with retina icons on non-retina displays (with background-size)